### PR TITLE
12 fragment view

### DIFF
--- a/src/components/hint.tsx
+++ b/src/components/hint.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import React from "react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./ui/tooltip";
+
+interface HintProps {
+  children: React.ReactNode;
+  text: string;
+  side?: "top" | "right" | "bottom" | "left";
+  align?: "start" | "center" | "end";
+}
+
+export const Hint = ({ children, text, align, side }: HintProps) => {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>{children}</TooltipTrigger>
+        <TooltipContent side={side} align={align}>
+          <p>{text}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+};

--- a/src/modules/projects/ui/components/fragment-web.tsx
+++ b/src/modules/projects/ui/components/fragment-web.tsx
@@ -24,8 +24,8 @@ const FragmentWeb = ({ data }: Props) => {
   };
 
   return (
-    <div className="flex items-center w-full h-full">
-      <div className="p-2 border-b bg-sidebar flex items-center gap-x-2">
+    <div className="flex flex-col items-center w-full h-full">
+      <div className="p-2 border-b bg-sidebar flex items-center gap-x-2 w-full">
         <Hint text="Refresh" side="bottom" align="start">
           <Button size="sm" variant="outline" onClick={onRefresh}>
             <RefreshCcwIcon />

--- a/src/modules/projects/ui/components/fragment-web.tsx
+++ b/src/modules/projects/ui/components/fragment-web.tsx
@@ -1,0 +1,71 @@
+import { Hint } from "@/components/hint";
+import { Button } from "@/components/ui/button";
+import { Fragment } from "@/generated/prisma";
+import { ExternalLinkIcon, RefreshCcwIcon } from "lucide-react";
+import React, { useState } from "react";
+
+interface Props {
+  data: Fragment;
+}
+
+const FragmentWeb = ({ data }: Props) => {
+  const [copied, setCopied] = useState(false);
+  const [fragmentKey, setFragmentKey] = useState(0);
+
+  const onRefresh = () => {
+    setFragmentKey((prev) => prev + 1);
+  };
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(data.sandboxUrl);
+    setCopied(true);
+
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="flex items-center w-full h-full">
+      <div className="p-2 border-b bg-sidebar flex items-center gap-x-2">
+        <Hint text="Refresh" side="bottom" align="start">
+          <Button size="sm" variant="outline" onClick={onRefresh}>
+            <RefreshCcwIcon />
+          </Button>
+        </Hint>
+        <Hint text="Click to copy" side="bottom">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={handleCopy}
+            disabled={!data.sandboxUrl || copied}
+            className="flex-1 justify-start text-start font-normal"
+          >
+            <span className="truncate">{data.sandboxUrl}</span>
+          </Button>
+        </Hint>
+        <Hint text="Open in a new tab" side="bottom" align="start">
+          <Button
+            size="sm"
+            disabled={!data.sandboxUrl}
+            variant="outline"
+            onClick={() => {
+              if (!data.sandboxUrl) return;
+
+              window.open(data.sandboxUrl, "_blank");
+            }}
+          >
+            <ExternalLinkIcon />
+          </Button>
+        </Hint>
+      </div>
+      <iframe
+        key={fragmentKey}
+        src={data.sandboxUrl}
+        className="h-full w-full"
+        sandbox="allow-forms allow-scripts allow-same-origin"
+        loading="lazy"
+      />
+    </div>
+  );
+};
+
+export default FragmentWeb;

--- a/src/modules/projects/ui/views/project-view.tsx
+++ b/src/modules/projects/ui/views/project-view.tsx
@@ -11,6 +11,7 @@ import MessagesContainer from "../components/messages-container";
 import { Suspense, useState } from "react";
 import { Fragment } from "@/generated/prisma";
 import ProjectHeader from "../components/project-header";
+import FragmentWeb from "../components/fragment-web";
 
 interface Props {
   projectId: string;
@@ -40,7 +41,7 @@ export const ProjectView = ({ projectId }: Props) => {
         </ResizablePanel>
         <ResizableHandle withHandle />
         <ResizablePanel defaultSize={65} minSize={50}>
-          TODO: PREVIEW
+          {!!activeFragment && <FragmentWeb data={activeFragment} />}
         </ResizablePanel>
       </ResizablePanelGroup>
     </div>


### PR DESCRIPTION
This pull request introduces a new `FragmentWeb` component to display and interact with web fragments, and adds a reusable `Hint` tooltip component. The main user-facing change is the replacement of a placeholder in the project view with the new interactive fragment preview panel, which includes refresh, copy URL, and open-in-new-tab actions, each with tooltips for improved usability.

**New UI Components:**

* Added a reusable `Hint` component in `src/components/hint.tsx` for providing tooltips to UI elements, supporting customizable position and alignment.
* Introduced a new `FragmentWeb` component in `src/modules/projects/ui/components/fragment-web.tsx` that displays a web fragment inside an iframe and provides buttons to refresh, copy the fragment URL, and open the fragment in a new tab, each enhanced with tooltips.

**Integration into Project View:**

* Imported and used the new `FragmentWeb` component in the project view, replacing the previous TODO preview placeholder with an interactive fragment preview panel. [[1]](diffhunk://#diff-e91945a6d4f08421d56fac244439a15ece9740eabb915eb5cbb79182a9bcfc5eR14) [[2]](diffhunk://#diff-e91945a6d4f08421d56fac244439a15ece9740eabb915eb5cbb79182a9bcfc5eL43-R44)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fragment preview functionality with actions to refresh content, copy preview URL, and open in a new browser tab.
  * Added reusable tooltip component for contextual hints throughout the interface.
  * Integrated fragment previews into the project view, replacing static placeholder text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->